### PR TITLE
Allow multiple entity managers

### DIFF
--- a/Extension/Builder/DoctrineTableBuilder.php
+++ b/Extension/Builder/DoctrineTableBuilder.php
@@ -393,10 +393,11 @@ class DoctrineTableBuilder extends TableBuilder
      */
     public function getClassMetaData()
     {
-        $container = $this->getTableFactory()->getContainer();
-        $cmf = $container->get('doctrine')->getEntityManager()->getMetadataFactory();
-
-        return $cmf->getMetadataFor($this->repository->getClassName());
+          $repo = new \ReflectionClass(get_class($this->repository));
+          $method = $repo->getMethod('getClassMetadata');
+          $method->setAccessible(true);
+          
+          return $method->invoke($this->repository);
     }
 
     /**


### PR DESCRIPTION
At the moment, the default entitymanager is always used to retrieve the class metadata. This will fail if the repository is managed by another entity manager.

We could add the entitymanager as a property to the tablebuilder or we can solve it via reflection and setting the protected getClassMetadata method from the repository to accessible.
